### PR TITLE
feat: Implement intelligent caching layer for OpenAI API

### DIFF
--- a/backend/backend.log
+++ b/backend/backend.log
@@ -1,0 +1,18 @@
+node:internal/modules/cjs/loader:1404
+  throw err;
+  ^
+
+Error: Cannot find module '/app/backend/backend/index.js'
+    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
+    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
+    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
+    at Function._load (node:internal/modules/cjs/loader:1211:37)
+    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
+    at node:internal/main/run_main_module:36:49 {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: []
+}
+
+Node.js v22.17.1

--- a/backend/index.js
+++ b/backend/index.js
@@ -7,6 +7,7 @@ const authRoutes = require('./routes/auth');
 const taskRoutes = require('./routes/tasks');
 const fileRoutes = require('./routes/files');
 const agentRoutes = require('./routes/agent');
+const chatRoutes = require('./routes/chat');
 
 // Middleware Imports
 const errorHandler = require('./middleware/errorHandler');
@@ -26,6 +27,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/files', fileRoutes);
 app.use('/api/agent', agentRoutes);
+app.use(chatRoutes);
 
 // Serve uploaded files statically
 // This makes files in the 'uploads' directory accessible via URL, e.g., http://localhost:3001/uploads/filename.jpg

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,15 +9,79 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@redis/client": "^5.7.0",
         "bcrypt": "^6.0.0",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.2",
-        "mysql2": "^3.14.3"
+        "mysql2": "^3.14.3",
+        "openai": "^5.11.0",
+        "pg": "^8.16.3",
+        "redis": "^5.7.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.7.0.tgz",
+      "integrity": "sha512-KtBHDH2Aw1BxYDQd87PJsdEmZcpMbD4oPzdBwB4IvSRmMovukO2NNGi5vpCHhCoicS83zu7cjX1fw79uFBZFJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.7.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.7.0.tgz",
+      "integrity": "sha512-YV3Knspdj9k6H6s4v8QRcj1WBxHt40vtPmszLKGwRUOUpUOLWSlI9oCUjprMDcQNzgSCXGXYdL/Aj6nT2+Ub0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.7.0.tgz",
+      "integrity": "sha512-VP3wtse1PSB/UjZAV1lWyDrWrrZcwi/cjb3L0lIarcIJ+EbHliB2QPml0Bvjz8F8F0eDJRtChJVXFc+jhGxCtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.7.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.7.0.tgz",
+      "integrity": "sha512-dDZIq8pZJnT+kZ9xRlLLi2Rvkd792z9eh31QRIwPr5wXjAXeaQ+Nf65em6dLpsxZ60MmhwDwLrBPJpYVjKPBPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.7.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.7.0.tgz",
+      "integrity": "sha512-AJTF9sz3y1MJAukgQW4Jw8zt8qGOE3+1d87pufOP35zsFBlHipGscpctoXiNMebfy0114y/FjSprr65LjbJQSQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.7.0"
       }
     },
     "node_modules/accepts": {
@@ -224,6 +288,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/concat-map": {
@@ -1162,6 +1235,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.11.0.tgz",
+      "integrity": "sha512-+AuTc5pVjlnTuA9zvn8rA/k+1RluPIx9AD4eDcnutv6JNwHHZxIhkFy+tmMKCvmMFDQzfA/r1ujvPWB19DQkYg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1180,6 +1274,95 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1191,6 +1374,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1277,6 +1499,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.7.0.tgz",
+      "integrity": "sha512-ZRbiWYBUYdDTopodRjCVwwCLThrkciPW3bOrkdMCW3nYEelBwUGN6SovmACDsiLUB7mnU3mXnaI5f0W7bDcwng==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.7.0",
+        "@redis/client": "5.7.0",
+        "@redis/json": "5.7.0",
+        "@redis/search": "5.7.0",
+        "@redis/time-series": "5.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/router": {
@@ -1464,6 +1702,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,12 +11,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@redis/client": "^5.7.0",
     "bcrypt": "^6.0.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.2",
-    "mysql2": "^3.14.3"
+    "mysql2": "^3.14.3",
+    "openai": "^5.11.0",
+    "pg": "^8.16.3",
+    "redis": "^5.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -1,0 +1,90 @@
+const express = require('express');
+const router = express.Router();
+const redisClient = require('../services/redisClient');
+const pgPool = require('../services/pgClient');
+const { OpenAI } = require('openai');
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function getEmbedding(text) {
+  const { data } = await openai.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text,
+  });
+  return data[0].embedding;
+}
+
+router.post('/api/chat', async (req, res) => {
+  try {
+    const { message } = req.body;
+    if (!message) return res.status(400).json({ error: 'Message required' });
+
+    // Layer 1 – Redis exact match
+    const redisKey = `chat:${message}`;
+    let cached = null;
+    try {
+      cached = await redisClient.get(redisKey);
+      if (cached) return res.json({ reply: cached, source: 'redis-cache' });
+    } catch (redisError) {
+      console.error('Redis GET error:', redisError.message);
+      // Proceed as cache miss
+    }
+
+    // Layer 2 – pgvector semantic search
+    const embedding = await getEmbedding(message);
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT answer, 1 - (embedding <=> $1) sim
+         FROM chat_embeddings
+         WHERE 1 - (embedding <=> $1) > 0.8
+         ORDER BY sim DESC LIMIT 1`,
+        [embedding],
+      );
+      if (rows.length) {
+        const answer = rows[0].answer;
+        try {
+          await redisClient.setEx(redisKey, 604800, answer); // 7 days
+        } catch (redisSetError) {
+          console.error('Redis SETEX error:', redisSetError.message);
+        }
+        return res.json({ reply: answer, source: 'pgvector-cache' });
+      }
+    } catch (pgError) {
+      console.error('pgvector SELECT error:', pgError.message);
+      // Proceed as cache miss
+    }
+
+    // Layer 3 – OpenAI Agent Mode
+    const gpt = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: message }],
+    });
+    const answer = gpt.choices[0].message.content;
+
+    // Persist to caches (best effort)
+    try {
+      await pgPool.query(
+        'INSERT INTO chat_embeddings (question, answer, embedding) VALUES ($1,$2,$3)',
+        [message, answer, embedding],
+      );
+    } catch (pgInsertError) {
+      console.error('pgvector INSERT error:', pgInsertError.message);
+    }
+    try {
+      await redisClient.setEx(redisKey, 604800, answer);
+    } catch (redisSetError) {
+      console.error('Redis SETEX error on new answer:', redisSetError.message);
+    }
+
+    res.json({ reply: answer, source: 'openai-api' });
+  } catch (e) {
+    console.error('General chat error:', e);
+    // Handle cases like OpenAI API failure
+    if (e.response) {
+        console.error(e.response.status, e.response.data);
+        return res.status(e.response.status).json(e.response.data);
+    }
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/backend/services/pgClient.js
+++ b/backend/services/pgClient.js
@@ -1,0 +1,8 @@
+const { Pool } = require('pg');
+module.exports = new Pool({
+  host: 'localhost',
+  port: 5432,
+  database: 'agent_cache',
+  user: 'agent_user',
+  password: 'AgentPass123',
+});

--- a/backend/services/redisClient.js
+++ b/backend/services/redisClient.js
@@ -1,0 +1,5 @@
+const { createClient } = require('redis');
+const redisClient = createClient();
+redisClient.connect().catch(console.error);
+redisClient.on('connect', () => console.log('Redis connected'));
+module.exports = redisClient;

--- a/frontend/pages/dashboard/ChatPage.tsx
+++ b/frontend/pages/dashboard/ChatPage.tsx
@@ -1,52 +1,21 @@
 import React, { useState, useRef, useEffect, FormEvent } from 'react';
+import React, { useState, useRef, useEffect, FormEvent } from 'react';
 import { ChatMessage, AttachedFile } from '../../types';
 import { PaperclipIcon, SendIcon, Spinner, UserIcon } from '../../components/icons';
-import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
-
-// Utility to convert file to base64
-const fileToGenerativePart = async (file: File) => {
-  const base64EncodedData = await new Promise<string>((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve((reader.result as string).split(',')[1]);
-    reader.readAsDataURL(file);
-  });
-  return {
-    inlineData: {
-      data: base64EncodedData,
-      mimeType: file.type,
-    },
-  };
-};
 
 const ChatPage = () => {
   const [messages, setMessages] = useState<ChatMessage[]>(() => {
-    // Lazy initialization to prevent module-level errors from crashing the app
     const initialMessage: ChatMessage = {
         id: 'init-1', 
-        text: 'سلام! من دستیار هوشمند شما هستم. چطور می‌توانم امروز به شما کمک کنم؟ می‌توانید سوال بپرسید یا فایلی را برای بررسی آپلود کنید.', 
+        text: 'سلام! من دستیار هوشمند شما هستم. چطور می‌توانم امروز به شما کمک کنم؟',
         sender: 'model', 
         timestamp: new Date().toLocaleTimeString('fa-IR', { hour: '2-digit', minute: '2-digit' }) 
     };
     return [initialMessage];
   });
   const [input, setInput] = useState('');
-  const [attachedFile, setAttachedFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [ai, setAi] = useState<GoogleGenAI | null>(null);
-  const [initError, setInitError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    // Effect hook is now solely responsible for initializing the AI service.
-    try {
-      const aiInstance = new GoogleGenAI({ apiKey: process.env.API_KEY });
-      setAi(aiInstance);
-    } catch (error) {
-        console.error("Failed to initialize GoogleGenAI:", error);
-        setInitError("خطا در راه‌اندازی سرویس هوش مصنوعی. لطفا از فعال بودن کلید API اطمینان حاصل کرده و صفحه را دوباره بارگیری کنید.");
-    }
-  }, []);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -54,42 +23,23 @@ const ChatPage = () => {
 
   const handleSendMessage = async (e: FormEvent) => {
     e.preventDefault();
-    if ((input.trim() === '' && !attachedFile) || isLoading || !ai) {
-        if (!ai) console.error("AI service is not initialized.");
+    if (input.trim() === '' || isLoading) {
         return;
     };
 
     setIsLoading(true);
     const userMessageText = input;
-    const userFile = attachedFile;
-    
-    // Reset inputs
     setInput('');
-    setAttachedFile(null);
-    if(fileInputRef.current) fileInputRef.current.value = "";
     
     const timestamp = new Date().toLocaleTimeString('fa-IR', { hour: '2-digit', minute: '2-digit' });
-
-    // Add user message to UI
-    let userMessageFile: AttachedFile | undefined = undefined;
-    if (userFile) {
-        const fileDataUrl = await new Promise<string>(resolve => {
-            const reader = new FileReader();
-            reader.onloadend = () => resolve(reader.result as string);
-            reader.readAsDataURL(userFile);
-        });
-        userMessageFile = { name: userFile.name, type: userFile.type, data: fileDataUrl };
-    }
 
     const userMessage: ChatMessage = {
       id: `user-${Date.now()}`,
       text: userMessageText,
       sender: 'user',
       timestamp,
-      file: userMessageFile,
     };
     
-    // Add a placeholder for the model's response
     const modelPlaceholderId = `model-${Date.now()}`;
     const modelPlaceholder: ChatMessage = {
         id: modelPlaceholderId,
@@ -102,33 +52,29 @@ const ChatPage = () => {
     setMessages(prev => [...prev, userMessage, modelPlaceholder]);
 
     try {
-        const contents: any = { parts: [] };
-        if (userMessageText) {
-            contents.parts.push({ text: userMessageText });
-        }
-        if (userFile) {
-            const filePart = await fileToGenerativePart(userFile);
-            contents.parts.push(filePart);
-        }
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: userMessageText }),
+      });
 
-        const result: GenerateContentResponse = await ai.models.generateContent({
-            model: 'gemini-2.5-flash',
-            contents: contents,
-        });
-        
-        const responseText = result.text;
-        
-        const modelMessage: ChatMessage = {
-            id: modelPlaceholderId,
-            text: responseText || "متاسفانه نتوانستم پاسخی تولید کنم.",
-            sender: 'model',
-            timestamp: new Date().toLocaleTimeString('fa-IR', { hour: '2-digit', minute: '2-digit' }),
-        };
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
 
-        setMessages(prev => prev.map(msg => msg.id === modelPlaceholderId ? modelMessage : msg));
+      const { reply } = await response.json();
+        
+      const modelMessage: ChatMessage = {
+          id: modelPlaceholderId,
+          text: reply || "متاسفانه نتوانستم پاسخی تولید کنم.",
+          sender: 'model',
+          timestamp: new Date().toLocaleTimeString('fa-IR', { hour: '2-digit', minute: '2-digit' }),
+      };
+
+      setMessages(prev => prev.map(msg => msg.id === modelPlaceholderId ? modelMessage : msg));
 
     } catch (error) {
-      console.error('Error sending message to Gemini:', error);
+      console.error('Error sending message:', error);
       const errorMessage: ChatMessage = {
           id: modelPlaceholderId,
           text: "خطایی در ارتباط با سرویس رخ داد. لطفا دوباره تلاش کنید.",
@@ -138,12 +84,6 @@ const ChatPage = () => {
       setMessages(prev => prev.map(msg => msg.id === modelPlaceholderId ? errorMessage : msg));
     } finally {
       setIsLoading(false);
-    }
-  };
-
-  const handleFileAttach = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-        setAttachedFile(e.target.files[0]);
     }
   };
 
@@ -157,13 +97,6 @@ const ChatPage = () => {
 
   return (
     <div className="flex flex-col h-full max-w-5xl mx-auto">
-      {initError ? (
-          <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
-              <svg xmlns="http://www.w3.org/2000/svg" className="w-16 h-16 text-red-500/80 mb-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"></path></svg>
-              <h2 className="text-xl font-bold text-white mb-2">خطای اتصال</h2>
-              <p className="text-slate-300 max-w-md">{initError}</p>
-          </div>
-      ) : (
       <>
         <div className="flex-1 p-4 space-y-6 overflow-y-auto">
           {messages.map(msg => (
@@ -178,19 +111,8 @@ const ChatPage = () => {
                   <div className="px-4 py-3"><TypingIndicator /></div>
                 ) : (
                   <>
-                    {msg.file?.type?.startsWith('image/') && (
-                      <img src={msg.file.data} alt={msg.file.name} className="max-w-full max-h-64 object-cover rounded-t-2xl" />
-                    )}
                     <div className="px-4 py-3">
                       {msg.text && <p className="text-sm whitespace-pre-wrap">{msg.text}</p>}
-                      
-                      {msg.file?.type && !msg.file.type.startsWith('image/') && (
-                        <div className="mt-2 p-2 bg-black/20 rounded-lg flex items-center gap-2">
-                            <PaperclipIcon className="w-4 h-4 text-slate-300 flex-shrink-0" />
-                            <span className="text-xs text-slate-300 truncate">{msg.file.name}</span>
-                        </div>
-                      )}
-                      
                       <p className={`text-xs mt-1.5 ${msg.sender === 'user' ? 'text-blue-200' : 'text-slate-400'} text-left`}>
                           {msg.timestamp}
                       </p>
@@ -205,32 +127,24 @@ const ChatPage = () => {
         </div>
 
         <div className="p-4 bg-transparent">
-          {attachedFile && (
-              <div className="mb-2 p-2 bg-white/10 rounded-lg flex items-center justify-between text-sm">
-                  <span className="text-slate-200 truncate">{attachedFile.name}</span>
-                  <button onClick={() => { setAttachedFile(null); if(fileInputRef.current) fileInputRef.current.value = ""; }} className="text-red-400 text-2xl">&times;</button>
-              </div>
-          )}
           <form onSubmit={handleSendMessage} className="flex items-center gap-2 p-2 bg-black/20 border border-white/10 rounded-xl">
-            <button type="button" onClick={() => fileInputRef.current?.click()} className="p-2 text-slate-300 hover:text-white transition-colors">
+            <button type="button" className="p-2 text-slate-400 cursor-not-allowed">
               <PaperclipIcon />
             </button>
-            <input type="file" ref={fileInputRef} onChange={handleFileAttach} className="hidden" />
             <input
               type="text"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder="پیام خود را بنویسید..."
               className="flex-1 bg-transparent text-white placeholder-slate-400 focus:outline-none"
-              disabled={isLoading || !ai}
+              disabled={isLoading}
             />
-            <button type="submit" disabled={isLoading || !ai || (!input.trim() && !attachedFile)} className="bg-gradient-to-r from-cyan-500 to-blue-500 text-white rounded-lg p-3 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity">
+            <button type="submit" disabled={isLoading || !input.trim()} className="bg-gradient-to-r from-cyan-500 to-blue-500 text-white rounded-lg p-3 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity">
               {isLoading ? <Spinner className="w-5 h-5"/> : <SendIcon />}
             </button>
           </form>
         </div>
       </>
-      )}
     </div>
   );
 };

--- a/server.log
+++ b/server.log
@@ -1,0 +1,10 @@
+[dotenv@17.2.1] injecting env (12) from .env -- tip: 🛠️  run anywhere with `dotenvx run -- yourcommand`
+Server is running on port 3001
+Error: connect ECONNREFUSED 127.0.0.1:6379
+    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+  errno: -111,
+  code: 'ECONNREFUSED',
+  syscall: 'connect',
+  address: '127.0.0.1',
+  port: 6379
+}


### PR DESCRIPTION
Adds a two-layer caching system to reduce latency and cost for OpenAI API calls.

- A new endpoint `/api/chat` is created in the Express backend to handle all chat requests.
- Layer 1: A Redis cache provides fast lookups for exact message matches.
- Layer 2: A PostgreSQL database with the pgvector extension provides semantic search for similar questions.
- If a request is not found in either cache, it is forwarded to the OpenAI API (gpt-4o). The result is then persisted in both caches for future requests.

The frontend `ChatPage.tsx` component has been updated to use this new `/api/chat` endpoint instead of calling an LLM service directly. The original implementation used Google Gemini, which has been replaced. File upload functionality has been disabled as the new endpoint only supports text.

The caching logic has been made resilient to database connection errors. If Redis or PostgreSQL are unavailable, the application logs the error and gracefully falls back to the OpenAI API, ensuring continued operation.